### PR TITLE
feat: Add "disable on mobile" setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,10 @@ export default class OpenTabSettingsPlugin extends Plugin {
 
         this.addSettingTab(new OpenTabSettingsPluginSettingTab(this.app, this));
 
+        if (this.isDisabledOnCurrentDevice()) {
+            return;
+        }
+
         this.registerMonkeyPatches();
 
         this.registerEvent(
@@ -317,6 +321,10 @@ export default class OpenTabSettingsPlugin extends Plugin {
     async updateSettings(settings: Partial<OpenTabSettingsPluginSettings>) {
         Object.assign(this.settings, settings);
         await this.saveData(this.settings);
+    }
+
+    private isDisabledOnCurrentDevice() {
+        return this.settings.disableOnMobile && (Platform.isPhone || Platform.isTablet);
     }
 
     private findMatchingLeaves(file: TFile) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export const MOD_CLICK_BEHAVIOR = {
 }
 
 export interface OpenTabSettingsPluginSettings {
+    disableOnMobile: boolean,
     openInNewTab: boolean,
     deduplicateTabs: boolean,
     deduplicateAcrossTabGroups: boolean,
@@ -32,6 +33,7 @@ export interface OpenTabSettingsPluginSettings {
 }
 
 export const DEFAULT_SETTINGS: OpenTabSettingsPluginSettings = {
+    disableOnMobile: false,
     openInNewTab: true,
     deduplicateTabs: true,
     deduplicateAcrossTabGroups: true,
@@ -50,6 +52,18 @@ export class OpenTabSettingsPluginSettingTab extends PluginSettingTab {
 
     display(): void {
         this.containerEl.empty();
+
+        new Setting(this.containerEl)
+            .setName('Disable on mobile')
+            .setDesc('Disable this plugin on phone and tablet. Requires restart to take effect.')
+            .addToggle(toggle =>
+                toggle
+                    .setValue(this.plugin.settings.disableOnMobile)
+                    .onChange(async (value) => {
+                        await this.plugin.updateSettings({disableOnMobile: value});
+                    })
+            );
+
         new Setting(this.containerEl)
             .setName('Always open in new tab')
             .setDesc('Open files in a new tab by default.')


### PR DESCRIPTION
A quick fix for Issue #15 -- This PR adds a boolean "Disable on mobile" which, when enabled, causes the plugin to do nothing when running on a mobile device such as a smartphone or a tablet. 

As of 2026-04-06, this PR can be merged into `main` or `dev`. 