### PR TITLE
feat: add Disable on this device toggle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,20 @@ const OVERRIDES = {
     opposite: buildOverride("tab", {newTabTabGroupPlacement: "opposite"}),
 }
 
+const DISABLED_KEY = "open-tab-settings:disabled-on-device";
+
+export function isDisabledOnDevice(): boolean {
+    return window.localStorage.getItem(DISABLED_KEY) === "true";
+}
+
+export function setDisabledOnDevice(value: boolean): void {
+    if (value) {
+        window.localStorage.setItem(DISABLED_KEY, "true");
+    } else {
+        window.localStorage.removeItem(DISABLED_KEY);
+    }
+}
+
 
 export default class OpenTabSettingsPlugin extends Plugin {
     settings: OpenTabSettingsPluginSettings = {...DEFAULT_SETTINGS};
@@ -68,6 +82,10 @@ export default class OpenTabSettingsPlugin extends Plugin {
         await this.loadSettings();
 
         this.addSettingTab(new OpenTabSettingsPluginSettingTab(this.app, this));
+
+        if (isDisabledOnDevice()) {
+            return;
+        }
 
         this.registerMonkeyPatches();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
-import OpenTabSettingsPlugin from "./main"
+import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
+import OpenTabSettingsPlugin, { isDisabledOnDevice, setDisabledOnDevice } from "./main"
 
 export const NEW_TAB_PLACEMENTS = {
     "after-active": "After active tab",
@@ -50,6 +50,25 @@ export class OpenTabSettingsPluginSettingTab extends PluginSettingTab {
 
     display(): void {
         this.containerEl.empty();
+
+        new Setting(this.containerEl)
+            .setName('Disable on this device')
+            .setDesc(
+                'When enabled, this plugin does nothing on the current device. ' +
+                'This setting is per-device and is not synced. Restart Obsidian or toggle the plugin off and on to apply.'
+            )
+            .addToggle(toggle =>
+                toggle
+                    .setValue(isDisabledOnDevice())
+                    .onChange((value) => {
+                        setDisabledOnDevice(value);
+                        new Notice(
+                            `Open Tab Settings will be ${value ? 'disabled' : 'enabled'} on this device after restart.`,
+                            5000,
+                        );
+                    })
+            );
+
         new Setting(this.containerEl)
             .setName('Always open in new tab')
             .setDesc('Open files in a new tab by default.')


### PR DESCRIPTION
Adds a per-device kill switch for the plugin. When enabled, the plugin registers only its settings tab and skips all behavior on the current device, leaving the synced settings untouched.

The flag is stored in localStorage (not in data.json) so it stays device-local. Toggling it shows a Notice prompting the user to restart Obsidian — or toggle the plugin off/on — to apply.

This addresses Issue #15 and requested changes in PR #60. Apologies for my tardiness; I started a new job during that conversation.