### PR TITLE
feat: exit preview mode when double-clicking file in left panel file list

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -159,6 +159,26 @@ export default class OpenTabSettingsPlugin extends Plugin {
             }
         }))
 
+        // Double-click on a file in the file explorer should confirm the preview tab (exit preview mode).
+        // This mirrors the built-in dblclick on tab header behavior.
+        this.registerDomEvent(document, "dblclick", (e: MouseEvent) => {
+            const target = (e.target as HTMLElement).closest('.nav-file-title');
+            if (!target) return;
+            if (!this.settings.previewTabs) return;
+
+            const filePath = target.getAttribute('data-path');
+            if (!filePath) return;
+
+            // Small delay to let the first click's async openFile finish setting up the preview leaf.
+            setTimeout(() => {
+                this.app.workspace.iterateAllLeaves(leaf => {
+                    if (leaf.openTabSettings?.isPreview && leaf.view.getState()?.file === filePath) {
+                        this.setLeafIsPreview(leaf, false);
+                    }
+                });
+            }, 100);
+        });
+
         this.register(() => {
             this.app.workspace.iterateAllLeaves(l => {
                 this.setLeafIsPreview(l, false);


### PR DESCRIPTION
## Summary

When "Preview tabs" is enabled, double-clicking a **tab header** already exits preview mode (existing behavior via `dblclick` on `tabHeaderEl`). However, double-clicking a file in **Obsidian's left panel file list** does nothing — the file stays in preview mode.

This PR extends the double-click-to-confirm behavior to the left panel file list, making it consistent with the tab header — and more closely matching VS Code's behavior, where double-clicking a file in the sidebar file list opens it as a permanent (non-preview) tab.

## Motivation

The "Preview tabs" feature is modeled after VS Code's preview tab behavior. In VS Code, double-clicking a file in the sidebar file list opens it as a permanent tab, not a preview tab. Currently this plugin only supports double-clicking the tab header to exit preview mode, which is a less discoverable interaction. Supporting double-click on the left panel file list makes the behavior more intuitive and consistent with the VS Code workflow that users already know.

## Changes

Added a `dblclick` event listener on `document` in `src/main.ts` that:

1. Checks if the click target is a `.nav-file-title` element (file item in the left panel)
2. Reads the file path from its `data-path` attribute
3. After a short delay (100ms, to let the first click's async `openFile` set up the preview leaf), finds any preview leaf showing that file
4. Calls `setLeafIsPreview(leaf, false)` to exit preview mode

The listener is registered via `registerDomEvent` for proper cleanup on plugin unload, and only activates when the `previewTabs` setting is enabled.

## Test plan

- [ ] Enable "Preview tabs" in plugin settings
- [ ] Single-click a file in the left panel file list → tab opens in preview mode (italic title)
- [ ] Double-click the same file in the left panel file list → tab exits preview mode (normal title)
- [ ] Verify that double-clicking the tab header still works as before
- [ ] Verify that the `dblclick` listener is properly cleaned up when the plugin is disabled